### PR TITLE
Fixed bug with multiple exclude strings

### DIFF
--- a/src/main/java/de/saupe/jeff/schedulecleaner/fixes/impl/ExcludeEvent.java
+++ b/src/main/java/de/saupe/jeff/schedulecleaner/fixes/impl/ExcludeEvent.java
@@ -20,10 +20,11 @@ public class ExcludeEvent extends Fix {
 
     public boolean findParameters(CalendarComponent event) {
         String text = event.toString();
+        boolean exclude = false;
         for (String parameter : getParameters()) {
-            if (!StringUtils.containsIgnoreCase(text, parameter))
-                return false;
+            if (StringUtils.containsIgnoreCase(text, parameter))
+                exclude = true;
         }
-        return true;
+        return exclude;
     }
 }


### PR DESCRIPTION
The ```return false``` causes later parameters not to be considered if the first one doesn't match.